### PR TITLE
Test fix

### DIFF
--- a/api/memegen.go
+++ b/api/memegen.go
@@ -95,9 +95,14 @@ func (h *MemeHandler) htmlBanner(gifs *[]string, w http.ResponseWriter) {
 }
 
 func (h *MemeHandler) getImageFromRequest(w http.ResponseWriter, r *http.Request) string {
-	vars := mux.Vars(r)
-	imageName, ok := vars["from"]
-	if !ok {
+	// vars := mux.Vars(r)
+	// imageName, ok := vars["from"]
+	// if !ok {
+	// 	http.Error(w, "missing 'from' parameter", http.StatusBadRequest)
+	// 	return ""
+	// }
+	imageName := r.FormValue("from")
+	if imageName == "" {
 		http.Error(w, "missing 'from' parameter", http.StatusBadRequest)
 		return ""
 	}

--- a/api/memegen_test.go
+++ b/api/memegen_test.go
@@ -13,40 +13,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setUp() *MemeHandler {
+var sut *MemeHandler
+
+func setUp() {
 	tempdir, err := ioutil.TempDir("", "memeoid-api")
 	if err != nil {
 		panic(err)
 	}
-	m := MemeHandler{
+	sut = &MemeHandler{
 		OutputPath: tempdir,
 		ImgPath:    "../img/fixtures/",
 		FontName:   "DejaVuSans",
 		MemeURL:    "url",
 	}
-	os.Mkdir(path.Join(tempdir, m.MemeURL), os.FileMode(755))
-	return &m
+	os.Mkdir(path.Join(tempdir, sut.MemeURL), os.FileMode(0755))
 }
 
-func tearDown(m *MemeHandler) {
-	os.RemoveAll(m.OutputPath)
+func tearDown() {
+	os.RemoveAll(sut.OutputPath)
+}
+
+func TestMain(m *testing.M) {
+	setUp()
+	code := m.Run()
+	tearDown()
+	os.Exit(code)
 }
 
 func TestUID(t *testing.T) {
-	m := setUp()
-	defer tearDown(m)
 	// Two requests with the same parameters create the same UID
 	reader := strings.NewReader("")
 	r := httptest.NewRequest(http.MethodGet, "http://localhost/w/api.php?first=a&last=b", reader)
 	r1 := httptest.NewRequest(http.MethodGet, "http://localhost/w/api.php?last=b&first=a", reader)
-	uid, err := m.UID(r)
+	uid, err := sut.UID(r)
 	assert.Nil(t, err, "could not calculate the UID: %v", err)
-	uid1, err := m.UID(r1)
+	uid1, err := sut.UID(r1)
 	assert.Nil(t, err, "could not calculate the UID: %v", err)
 	assert.Equal(t, uid, uid1, "expected the UIDs to be equal for the same query parameters")
 	// But this is case-sensitive.
 	r1 = httptest.NewRequest(http.MethodGet, "http://localhost/w/api.php?last=b&First=a", reader)
-	uid1, err = m.UID(r1)
+	uid1, err = sut.UID(r1)
 	assert.Nil(t, err, "could not calculate the UID: %v", err)
 	assert.NotEqual(t, uid, uid1, "expected the UIDs to be different for different capitalizations")
 }
@@ -62,20 +68,18 @@ var testListGifs = []struct {
 }
 
 func TestListGifs(t *testing.T) {
-	h := setUp()
-	defer tearDown(h)
 	reader := strings.NewReader("")
-	originalPath := h.ImgPath
+	originalPath := sut.ImgPath
 	for _, test := range testListGifs {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/gifs", reader)
 		req.Header.Set("Accept", "text/json")
 		rec := httptest.NewRecorder()
 		if test.Path != "" {
-			h.ImgPath = test.Path
+			sut.ImgPath = test.Path
 		} else {
-			h.ImgPath = originalPath
+			sut.ImgPath = originalPath
 		}
-		h.ListGifs(rec, req)
+		sut.ListGifs(rec, req)
 		response := rec.Result()
 		if test.ContentType != "" {
 			assert.Equal(t, []string{test.ContentType}, response.Header["Content-Type"])
@@ -102,19 +106,17 @@ var testMemeGenerate = []struct {
 }
 
 func TestMemeGenerate(t *testing.T) {
-	h := setUp()
-	defer tearDown(h)
 	for _, test := range testMemeGenerate {
 		reader := strings.NewReader("")
 		req := httptest.NewRequest(http.MethodGet, test.Uri, reader)
 		rec := httptest.NewRecorder()
-		h.MemeFromRequest(rec, req)
+		sut.MemeFromRequest(rec, req)
 		response := rec.Result()
 		assert.Equal(t, test.StatusCode, response.StatusCode)
 		if test.FileGenerated {
-			uid, err := h.UID(req)
+			uid, err := sut.UID(req)
 			assert.Nil(t, err)
-			filePath := path.Join(h.OutputPath, fmt.Sprintf("%s.gif", uid))
+			filePath := path.Join(sut.OutputPath, fmt.Sprintf("%s.gif", uid))
 			assert.FileExists(t, filePath)
 			assert.Contains(t, response.Header["Location"][0], fmt.Sprintf("/url/%s", uid))
 		}

--- a/api/memegen_test.go
+++ b/api/memegen_test.go
@@ -131,15 +131,13 @@ func (s *MemeGenTestSuite) TestMemeGenerate() {
 			response := rec.Result()
 			s.Equal(tc.StatusCode, response.StatusCode)
 			if tc.FileGenerated {
-				locationPrefix := fmt.Sprintf("/%s/", s.Sut.MemeUrl
+				locationPrefix := fmt.Sprintf("/%s/", baseMemeUrl)
 				locationHeader, ok := response.Header["Location"]
 				s.True(ok, "response should include a Location header")
 				s.NotEmpty(locationHeader, "response should include a Location header")
+				
 				// Extract location on disk from the Location Header
 				fileName := locationHeader[0][len(locationPrefix):]
-				
-				
-				fileName := response.Header["Location"][0][len(locationPrefix):]
 				filePath := path.Join(s.TempDir, fileName)
 				s.FileExists(filePath)
 			}

--- a/api/memegen_test.go
+++ b/api/memegen_test.go
@@ -82,17 +82,17 @@ func (s *MemeGenTestSuite) TestListGifs() {
 	for _, tc := range testCases {
 		testName := fmt.Sprintf("Path: %s - ContentType: %s - Status: %s - Body: %s", tc.Path, tc.ContentType, tc.Status, tc.Body)
 		s.Run(testName, func() {
+			s.Sut.ImgPath = baseImgPath
 			if tc.Path != "" {
 				s.Sut.ImgPath = tc.Path
 			}
-
 			req := httptest.NewRequest(http.MethodGet, "http://localhost/gifs", strings.NewReader(""))
 			req.Header.Set("Accept", "text/json")
 			rec := httptest.NewRecorder()
 
 			s.Sut.ListGifs(rec, req)
+			
 			response := rec.Result()
-
 			s.Equal(tc.Status, response.Status)
 			if tc.ContentType != "" {
 				s.Equal([]string{tc.ContentType}, response.Header["Content-Type"])
@@ -117,6 +117,8 @@ func (s *MemeGenTestSuite) TestMemeGenerate() {
 		{"http://localhost/w/api.php?from=lala", http.StatusNotFound, false},
 		{"http://localhost/w/api.php?from=earth.gif", http.StatusBadRequest, false},
 		{"http://localhost/w/api.php?from=earth.gif&top=test", http.StatusPermanentRedirect, true},
+		{"http://localhost/w/api.php?from=earth.gif&bottom=test", http.StatusPermanentRedirect, true},
+		{"http://localhost/w/api.php?from=earth.gif&bottom=test&top=test", http.StatusPermanentRedirect, true},
 	}
 	for _, tc := range testCases {
 		testName := fmt.Sprintf("Uri: %s - StatusCode: %d - Genereate: %t", tc.Uri, tc.StatusCode, tc.FileGenerated)
@@ -125,8 +127,8 @@ func (s *MemeGenTestSuite) TestMemeGenerate() {
 			rec := httptest.NewRecorder()
 
 			s.Sut.MemeFromRequest(rec, req)
+			
 			response := rec.Result()
-
 			s.Equal(tc.StatusCode, response.StatusCode)
 			if tc.FileGenerated {
 				locationPrefix := "/" + baseMemeUrl + "/"

--- a/api/memegen_test.go
+++ b/api/memegen_test.go
@@ -131,7 +131,14 @@ func (s *MemeGenTestSuite) TestMemeGenerate() {
 			response := rec.Result()
 			s.Equal(tc.StatusCode, response.StatusCode)
 			if tc.FileGenerated {
-				locationPrefix := "/" + baseMemeUrl + "/"
+				locationPrefix := fmt.Sprintf("/%s/", s.Sut.MemeUrl
+				locationHeader, ok := response.Header["Location"]
+				s.True(ok, "response should include a Location header")
+				s.NotEmpty(locationHeader, "response should include a Location header")
+				// Extract location on disk from the Location Header
+				fileName := locationHeader[0][len(locationPrefix):]
+				
+				
 				fileName := response.Header["Location"][0][len(locationPrefix):]
 				filePath := path.Join(s.TempDir, fileName)
 				s.FileExists(filePath)

--- a/api/memegen_test.go
+++ b/api/memegen_test.go
@@ -72,72 +72,74 @@ func (s *MemeGenTestSuite) TestUID() {
 	s.NotEqual(uid, uid1, "expected the UIDs to be different for different capitalizations")
 }
 
-var testListGifs = []struct {
-	Path        string
-	ContentType string
-	Status      string
-	Body        string
-}{
-	{"", "application/json", "200 OK", `["badfile.gif","earth.gif"]`},
-	{"/nonexistent", "", "404 Not Found", ""},
-}
-
 func (s *MemeGenTestSuite) TestListGifs() {
-	reader := strings.NewReader("")
 	originalPath := s.Sut.ImgPath
-	for _, test := range testListGifs {
-		req := httptest.NewRequest(http.MethodGet, "http://localhost/gifs", reader)
-		req.Header.Set("Accept", "text/json")
-		rec := httptest.NewRecorder()
-		if test.Path != "" {
-			s.Sut.ImgPath = test.Path
-		} else {
-			s.Sut.ImgPath = originalPath
-		}
-		s.Sut.ListGifs(rec, req)
-		response := rec.Result()
-		if test.ContentType != "" {
-			s.Equal([]string{test.ContentType}, response.Header["Content-Type"])
-		}
-		if test.Body != "" {
-			defer response.Body.Close()
-			body, err := ioutil.ReadAll(response.Body)
-			s.Nil(err)
-			s.Equal(test.Body, string(body))
-		}
-		s.Equal(test.Status, response.Status)
+	var testCases = []struct {
+		Path        string
+		ContentType string
+		Status      string
+		Body        string
+	}{
+		{"", "application/json", "200 OK", `["badfile.gif","earth.gif"]`},
+		{"/nonexistent", "", "404 Not Found", ""},
+	}
+	for _, tc := range testCases {
+		testName := fmt.Sprintf("Path: %s - ContentType: %s - Status: %s - Body: %s", tc.Path, tc.ContentType, tc.Status, tc.Body)
+		s.Run(testName, func(){
+			req := httptest.NewRequest(http.MethodGet, "http://localhost/gifs", strings.NewReader(""))
+			req.Header.Set("Accept", "text/json")
+			rec := httptest.NewRecorder()
+			if tc.Path != "" {
+				s.Sut.ImgPath = tc.Path
+			} else {
+				s.Sut.ImgPath = originalPath
+			}
+			s.Sut.ListGifs(rec, req)
+			response := rec.Result()
+			if tc.ContentType != "" {
+				s.Equal([]string{tc.ContentType}, response.Header["Content-Type"])
+			}
+			if tc.Body != "" {
+				defer response.Body.Close()
+				body, err := ioutil.ReadAll(response.Body)
+				s.Nil(err)
+				s.Equal(tc.Body, string(body))
+			}
+			s.Equal(tc.Status, response.Status)
+		})
 	}
 }
 
-var testMemeGenerate = []struct {
-	Uri           string
-	StatusCode    int
-	FileGenerated bool
-}{
-	{"http://localhost/w/api.php", http.StatusBadRequest, false},
-	{"http://localhost/w/api.php?from=lala", http.StatusNotFound, false},
-	{"http://localhost/w/api.php?from=earth.gif", http.StatusBadRequest, false},
-	{"http://localhost/w/api.php?from=earth.gif&top=test", http.StatusPermanentRedirect, true},
-}
-
 func (s *MemeGenTestSuite) TestMemeGenerate() {
-	for _, test := range testMemeGenerate {
-
-		req := httptest.NewRequest(http.MethodGet, test.Uri, strings.NewReader(""))
-		rec := httptest.NewRecorder()
-
-		s.Sut.MemeFromRequest(rec, req)
-		response := rec.Result()
-
-		s.Equal(test.StatusCode, response.StatusCode)
-		
-		if test.FileGenerated {
-			uid, err := s.Sut.UID(req)
-			s.Nil(err)
-			filePath := path.Join(s.Sut.OutputPath, fmt.Sprintf("%s.gif", uid))
-			s.FileExists(filePath)
-			s.Contains(response.Header["Location"][0], fmt.Sprintf("/url/%s", uid))
-		}
+	var testCases = []struct {
+		Uri           string
+		StatusCode    int
+		FileGenerated bool
+	}{
+		{"http://localhost/w/api.php", http.StatusBadRequest, false},
+		{"http://localhost/w/api.php?from=lala", http.StatusNotFound, false},
+		{"http://localhost/w/api.php?from=earth.gif", http.StatusBadRequest, false},
+		{"http://localhost/w/api.php?from=earth.gif&top=test", http.StatusPermanentRedirect, true},
+	}
+	for _, tc := range testCases {
+		testName := fmt.Sprintf("Uri: %s - StatusCode: %d - Genereate: %t", tc.Uri, tc.StatusCode, tc.FileGenerated)
+		s.Run(testName, func() {
+			req := httptest.NewRequest(http.MethodGet, tc.Uri, strings.NewReader(""))
+			rec := httptest.NewRecorder()
+	
+			s.Sut.MemeFromRequest(rec, req)
+			response := rec.Result()
+	
+			s.Equal(tc.StatusCode, response.StatusCode)
+			
+			if tc.FileGenerated {
+				uid, err := s.Sut.UID(req)
+				s.Nil(err)
+				filePath := path.Join(s.Sut.OutputPath, fmt.Sprintf("%s.gif", uid))
+				s.FileExists(filePath)
+				s.Contains(response.Header["Location"][0], fmt.Sprintf("/url/%s", uid))
+			}
+		})
 	}
 }
 

--- a/img/template_test.go
+++ b/img/template_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// TODO: this struct is the same as image_test.go:ImageTestSuite
+// Refactoring might be taken into account in order to reduce code duplication
 type TemplateTestSuite struct {
 	suite.Suite
 	fontPath string

--- a/img/template_test.go
+++ b/img/template_test.go
@@ -1,37 +1,30 @@
 package img
 
 import (
+	"fmt"
 	"image"
 	"image/gif"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/flopp/go-findfont"
+	"github.com/stretchr/testify/suite"
 )
 
-var testGetGif = []struct {
-	path string
-	err  bool
-}{
-	{"fixtures/earth.gif", false},
-	{"fixtures/non-existent.gif", true},
-	{"fixtures/badfile.gif", true},
+type TemplateTestSuite struct {
+	suite.Suite
+	fontPath string
 }
 
-func TestGetGif(t *testing.T) {
-	for _, test := range testGetGif {
-		m := MemeTemplate{gifPath: test.path}
-		_, err := m.GetGif()
-		if test.err && err == nil {
-			t.Errorf("test loading %s should have generated an error: %v", test.path, err)
-		}
-		if !test.err && err != nil {
-			t.Errorf("test loading %s should have not generated an error: %v", test.path, err)
-		}
+func (s *TemplateTestSuite) SetupSuite() {
+	fontPath, err := findfont.Find(defaultFont)
+	if err != nil {
+		panic(err)
 	}
+	s.fontPath = fontPath
 }
 
-func TestGetMeme(t *testing.T) {
-	box := TextBox{Width: 100, Height: 50, Center: image.Point{200, 200}, FontPath: loadFont()}
+func (s *TemplateTestSuite) TestGetMeme() {
+	box := TextBox{Width: 100, Height: 50, Center: image.Point{200, 200}, FontPath: s.fontPath}
 	tpl := MemeTemplate{
 		gifPath:     "fixtures/earth.gif",
 		boxes:       []TextBox{box},
@@ -42,13 +35,41 @@ func TestGetMeme(t *testing.T) {
 	}
 	// Meme with no text provided => error
 	m, err := tpl.GetMeme()
-	assert.Error(t, err, "no text provided should cause a failure")
+	s.Error(err, "no text provided should cause a failure")
 	m, err = tpl.GetMeme("test")
-	assert.Nil(t, err, "error loading the meme: %v", err)
-	assert.Equal(t, *(*m.TextBoxes)[0].Txt, "test", "Not correctly assigned text to textbox")
-	assert.Equal(t, (*m.TextBoxes)[0].FontSize, 52.0, "Not correctly set the font size")
-	assert.IsType(t, &gif.GIF{}, m.Gif, "A gif should be loaded")
+	s.Nil(err, "error loading the meme: %v", err)
+	s.Equal(*(*m.TextBoxes)[0].Txt, "test", "Not correctly assigned text to textbox")
+	s.Equal((*m.TextBoxes)[0].FontSize, 52.0, "Not correctly set the font size")
+	s.IsType(&gif.GIF{}, m.Gif, "A gif should be loaded")
 	tpl.gifPath = "fixtures/badfile.gif"
 	m, err = tpl.GetMeme("test")
-	assert.Error(t, err, "Should not generate a meme if the gif is corrupted")
+	s.Error(err, "Should not generate a meme if the gif is corrupted")
+}
+
+func (s *TemplateTestSuite) TestGetGif() {
+	var testGetGif = []struct {
+		path string
+		err  bool
+	}{
+		{"fixtures/earth.gif", false},
+		{"fixtures/non-existent.gif", true},
+		{"fixtures/badfile.gif", true},
+	}
+	for _, tc := range testGetGif {
+		testName := fmt.Sprintf("path: %s - err: %t", tc.path, tc.err)
+		s.Run(testName, func() {
+			m := MemeTemplate{gifPath: tc.path}
+			_, err := m.GetGif()
+			if tc.err && err == nil {
+				s.Errorf(nil, "test loading %s should have generated an error: %v", tc.path, err)
+			}
+			if !tc.err && err != nil {
+				s.Errorf(err, "test loading %s should have not generated an error: %v", tc.path, err)
+			}
+		})
+	}
+}
+
+func TestTemplateTestSuite(t *testing.T) {
+	suite.Run(t, new(TemplateTestSuite))
 }


### PR DESCRIPTION
**Tests**
Refactor tests using `testify` _Suite_ feature
Rewrite table-driven tests according to subtests guidelines (https://blog.golang.org/subtests)

**Bug fix**
Fix bug in `api/memegen.go:getImageFromRequest()`.
It uses the `mux.Vars()` method but `mux` is not correctly initialized and configured in the test. The initialization and configuration are spread across is the `api/controller.go` and `cmd/serve.go` files. Therefore it is very harmful to recreate a completely new `mux.NewRouter()` in the test without all the handling function used in those files. I also prefer to leave the old code commented on for further decisions. My suggestion is to refactor the routing and route handling in order o have a more testable and logically separated code.